### PR TITLE
Add CS2 tournament landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CS2: Aurora Clash — Киберспортивный турнир</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="hero" id="top">
+        <div class="overlay"></div>
+        <div class="container">
+            <nav class="navigation">
+                <a href="#top" class="logo">Aurora Clash</a>
+                <ul class="nav-links">
+                    <li><a href="#about">О турнире</a></li>
+                    <li><a href="#schedule">Расписание</a></li>
+                    <li><a href="#teams">Команды</a></li>
+                    <li><a href="#prizes">Призы</a></li>
+                    <li><a href="#register" class="btn btn-small">Регистрация</a></li>
+                </ul>
+            </nav>
+            <div class="hero-content">
+                <p class="eyebrow">12–14 июля 2024 • Москва &amp; онлайн</p>
+                <h1>Главная арена CS2 этого лета</h1>
+                <p class="lead">Присоединяйся к Aurora Clash — зрелищному турниру с участием лучших коллективов СНГ и открытой квалификацией для амбициозных команд.</p>
+                <div class="hero-actions">
+                    <a href="#register" class="btn">Подать заявку</a>
+                    <a href="#stream" class="btn btn-secondary">Смотреть трансляцию</a>
+                </div>
+                <div class="hero-stats">
+                    <div>
+                        <span class="value">$25 000</span>
+                        <span class="label">Призовой фонд</span>
+                    </div>
+                    <div>
+                        <span class="value">16</span>
+                        <span class="label">Команд</span>
+                    </div>
+                    <div>
+                        <span class="value">2</span>
+                        <span class="label">Дня LAN-финала</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="gradient"></div>
+    </header>
+
+    <main>
+        <section class="section" id="about">
+            <div class="container split">
+                <div>
+                    <h2>О турнире</h2>
+                    <p>Aurora Clash — это ежегодный киберспортивный фестиваль, посвящённый Counter-Strike 2. В 2024 году турнир объединяет топовые коллективы региона и открывает дорогу новым талантам через квалификации.</p>
+                    <div class="highlight-grid">
+                        <article>
+                            <h3>Формат</h3>
+                            <p>Закрытые квалификации онлайн, затем групповой этап и финальный LAN на площадке Aurora Arena.</p>
+                        </article>
+                        <article>
+                            <h3>Покрытие</h3>
+                            <p>Многоязычные трансляции, аналитика с участием звёзд CS-сцены и интерактив с чатом зрителей.</p>
+                        </article>
+                        <article>
+                            <h3>Инфраструктура</h3>
+                            <p>Игровые станции с оборудованием премиум-класса, зона для болельщиков и фан-мит с профессиональными игроками.</p>
+                        </article>
+                    </div>
+                </div>
+                <div class="card countdown" id="stream">
+                    <h3>До старта трансляции:</h3>
+                    <div class="countdown-timer" id="countdown">
+                        <div><span id="days">00</span><small>дней</small></div>
+                        <div><span id="hours">00</span><small>часов</small></div>
+                        <div><span id="minutes">00</span><small>минут</small></div>
+                        <div><span id="seconds">00</span><small>секунд</small></div>
+                    </div>
+                    <p>Первый матч стартует 12 июля в 12:00 (MSK). Подписывайся на уведомления, чтобы не пропустить живой эфир.</p>
+                    <a class="btn btn-outline" href="https://twitch.tv" target="_blank" rel="noopener">Перейти на Twitch</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section dark" id="schedule">
+            <div class="container">
+                <h2>Расписание этапов</h2>
+                <div class="timeline">
+                    <div class="stage">
+                        <h3>Открытые квалификации</h3>
+                        <p>18–26 июня • Онлайн</p>
+                        <ul>
+                            <li>Best-of-1 до топ-32</li>
+                            <li>Best-of-3 решающие матчи</li>
+                            <li>4 команды проходят в закрытый этап</li>
+                        </ul>
+                    </div>
+                    <div class="stage">
+                        <h3>Закрытый этап</h3>
+                        <p>30 июня – 4 июля • Онлайн</p>
+                        <ul>
+                            <li>Групповой раунд Robin, 2 группы по 6 команд</li>
+                            <li>Топ-2 каждой группы выходят в плей-офф</li>
+                            <li>Матчи в формате Best-of-3</li>
+                        </ul>
+                    </div>
+                    <div class="stage">
+                        <h3>LAN-финал</h3>
+                        <p>12–14 июля • Aurora Arena</p>
+                        <ul>
+                            <li>Сцена на 1000 зрителей</li>
+                            <li>Плей-офф Double Elimination</li>
+                            <li>Большой финал Best-of-5</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="teams">
+            <div class="container">
+                <h2>Приглашённые команды</h2>
+                <div class="team-grid">
+                    <article class="team-card">
+                        <h3>Polar Owls</h3>
+                        <p>Чемпионы прошлого сезона, известные агрессивным стилем и блиц-атаками на карте Nuke.</p>
+                        <span class="tag">#1 Seed</span>
+                    </article>
+                    <article class="team-card">
+                        <h3>Nova Five</h3>
+                        <p>Молодой состав, который ворвался в топ-10 ESL World Ranking в течение одного сезона.</p>
+                        <span class="tag">Wild Card</span>
+                    </article>
+                    <article class="team-card">
+                        <h3>Red Vipers</h3>
+                        <p>Опытная пятёрка со взрывной атакой и легендарным снайпером «NEON».</p>
+                        <span class="tag">Invited</span>
+                    </article>
+                    <article class="team-card">
+                        <h3>Solaris</h3>
+                        <p>Славятся дисциплинированной защитой и продуманными сетапами гранат.</p>
+                        <span class="tag">Invited</span>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="prizes">
+            <div class="container split">
+                <div>
+                    <h2>Призовой фонд</h2>
+                    <p>Призовой фонд в размере $25 000 распределяется между участниками LAN-финала следующим образом:</p>
+                    <ul class="prize-list">
+                        <li><span>1 место</span><span>$12 500 + слот на Aurora Masters 2024</span></li>
+                        <li><span>2 место</span><span>$6 500</span></li>
+                        <li><span>3 место</span><span>$4 000</span></li>
+                        <li><span>4 место</span><span>$2 000</span></li>
+                    </ul>
+                    <p>Дополнительные номинации: MVP турнира, лучший клатчер и приз зрительских симпатий.</p>
+                </div>
+                <div class="card">
+                    <h3>Партнёры турнира</h3>
+                    <ul class="partner-list">
+                        <li>Aurora Technologies</li>
+                        <li>HyperNova Gear</li>
+                        <li>Esports Plaza</li>
+                        <li>Streamline Media</li>
+                    </ul>
+                    <p>Хотите стать партнёром? Свяжитесь с нами по адресу <a href="mailto:partners@auroraclash.gg">partners@auroraclash.gg</a>.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section dark" id="register">
+            <div class="container split">
+                <div>
+                    <h2>Успей зарегистрироваться</h2>
+                    <p>Команды с рейтингом FACEIT 6 и выше могут принять участие в открытых квалификациях. Заполните форму и ожидайте приглашения на ближайший турнир.</p>
+                    <ol class="steps">
+                        <li>Подготовьте ссылку на командный профиль и список игроков.</li>
+                        <li>Укажите контакт капитана и предпочтительные даты.</li>
+                        <li>Получите подтверждение и инструкции по матчам.</li>
+                    </ol>
+                </div>
+                <form class="card form">
+                    <label>
+                        Название команды
+                        <input type="text" name="team" placeholder="Например, Arctic Flame" required>
+                    </label>
+                    <label>
+                        Ссылка на командный профиль
+                        <input type="url" name="profile" placeholder="https://faceit.com/..." required>
+                    </label>
+                    <label>
+                        Контакт капитана
+                        <input type="email" name="captain" placeholder="captain@email.com" required>
+                    </label>
+                    <label>
+                        Регион
+                        <select name="region" required>
+                            <option value="">Выберите регион</option>
+                            <option value="ru">Россия</option>
+                            <option value="cis">СНГ</option>
+                            <option value="eu">Европа</option>
+                            <option value="other">Другой</option>
+                        </select>
+                    </label>
+                    <label>
+                        Сообщение
+                        <textarea name="message" rows="4" placeholder="Расскажите о достижениях команды"></textarea>
+                    </label>
+                    <button type="submit" class="btn">Отправить заявку</button>
+                    <p class="form-note">Нажимая «Отправить заявку», вы соглашаетесь с <a href="#">правилами турнира</a>.</p>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container footer-content">
+            <div>
+                <span class="logo">Aurora Clash</span>
+                <p>© 2024 Aurora Esports. Все права защищены.</p>
+            </div>
+            <div class="footer-links">
+                <a href="#about">О турнире</a>
+                <a href="#schedule">Расписание</a>
+                <a href="#register">Регистрация</a>
+                <a href="mailto:info@auroraclash.gg">info@auroraclash.gg</a>
+            </div>
+            <div class="socials">
+                <a href="https://vk.com" target="_blank" rel="noopener" aria-label="VK">VK</a>
+                <a href="https://t.me" target="_blank" rel="noopener" aria-label="Telegram">TG</a>
+                <a href="https://youtube.com" target="_blank" rel="noopener" aria-label="YouTube">YT</a>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const targetDate = new Date('2024-07-12T12:00:00+03:00').getTime();
+        const daysEl = document.getElementById('days');
+        const hoursEl = document.getElementById('hours');
+        const minutesEl = document.getElementById('minutes');
+        const secondsEl = document.getElementById('seconds');
+
+        function updateCountdown() {
+            const now = new Date().getTime();
+            const difference = targetDate - now;
+
+            if (difference <= 0) {
+                daysEl.textContent = '00';
+                hoursEl.textContent = '00';
+                minutesEl.textContent = '00';
+                secondsEl.textContent = '00';
+                return;
+            }
+
+            const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+            const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+            const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+            const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+
+            daysEl.textContent = String(days).padStart(2, '0');
+            hoursEl.textContent = String(hours).padStart(2, '0');
+            minutesEl.textContent = String(minutes).padStart(2, '0');
+            secondsEl.textContent = String(seconds).padStart(2, '0');
+        }
+
+        updateCountdown();
+        setInterval(updateCountdown, 1000);
+    </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,512 @@
+:root {
+    --bg: #060613;
+    --bg-secondary: #101024;
+    --bg-contrast: #15152d;
+    --accent: #59c1ff;
+    --accent-strong: #ff5db1;
+    --text: #e6e8f2;
+    --muted: #a6abc7;
+    --card-radius: 18px;
+    --shadow: 0 24px 60px rgba(8, 12, 30, 0.55);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Rubik', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+}
+
+a:hover,
+a:focus {
+    color: var(--accent);
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.container {
+    width: min(1120px, 90vw);
+    margin: 0 auto;
+}
+
+.section {
+    padding: 6rem 0;
+}
+
+.section.dark {
+    background: radial-gradient(circle at top right, rgba(89, 193, 255, 0.08), transparent 55%),
+        radial-gradient(circle at bottom left, rgba(255, 93, 177, 0.08), transparent 60%),
+        var(--bg-secondary);
+}
+
+.hero {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background: url('https://images.unsplash.com/photo-1618005198919-d3d4b5a92eee?auto=format&fit=crop&w=1600&q=80') center/cover no-repeat;
+}
+
+.hero .overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(6, 6, 19, 0.88) 0%, rgba(6, 6, 19, 0.94) 40%, rgba(16, 16, 36, 0.92) 65%, rgba(20, 24, 60, 0.92) 100%);
+}
+
+.hero .gradient {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 70% 30%, rgba(89, 193, 255, 0.3), transparent 55%),
+        radial-gradient(circle at 30% 80%, rgba(255, 93, 177, 0.25), transparent 60%);
+    mix-blend-mode: screen;
+}
+
+.hero .container {
+    position: relative;
+    z-index: 2;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+}
+
+.navigation {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4rem;
+}
+
+.logo {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.nav-links a {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--muted);
+    transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+    color: var(--text);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+    color: #0b0b18;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+}
+
+.btn:hover,
+.btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px rgba(89, 193, 255, 0.35);
+}
+
+.btn-secondary {
+    background: rgba(230, 232, 242, 0.1);
+    color: var(--text);
+    border: 1px solid rgba(230, 232, 242, 0.2);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+    color: var(--text);
+    box-shadow: 0 12px 30px rgba(9, 16, 48, 0.45);
+}
+
+.btn-outline {
+    background: transparent;
+    color: var(--text);
+    border: 1px solid rgba(230, 232, 242, 0.3);
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+    background: rgba(230, 232, 242, 0.1);
+}
+
+.btn-small {
+    padding: 0.55rem 1.4rem;
+    font-size: 0.9rem;
+}
+
+.hero-content {
+    max-width: 640px;
+}
+
+.hero-content .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    font-size: 0.8rem;
+    color: var(--accent);
+    margin-bottom: 1.5rem;
+}
+
+.hero-content h1 {
+    font-size: clamp(2.75rem, 5vw, 4rem);
+    line-height: 1.1;
+    margin-bottom: 1.5rem;
+}
+
+.hero-content .lead {
+    font-size: 1.1rem;
+    color: var(--muted);
+    margin-bottom: 2.4rem;
+}
+
+.hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.5rem;
+    margin-top: 3rem;
+}
+
+.hero-stats .value {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.hero-stats .label {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.split {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: start;
+}
+
+.highlight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.75rem;
+    margin-top: 2.5rem;
+}
+
+.card {
+    background: rgba(14, 16, 38, 0.75);
+    border: 1px solid rgba(89, 193, 255, 0.1);
+    border-radius: var(--card-radius);
+    padding: 2.25rem;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(12px);
+}
+
+.countdown-timer {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(60px, 1fr));
+    gap: 1rem;
+    text-align: center;
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 1.5rem 0;
+}
+
+.countdown-timer span {
+    display: block;
+    font-size: 2rem;
+}
+
+.countdown-timer small {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.timeline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.stage {
+    background: rgba(12, 14, 34, 0.6);
+    border: 1px solid rgba(255, 93, 177, 0.18);
+    border-radius: var(--card-radius);
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.stage::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 93, 177, 0.25), transparent 60%);
+    opacity: 0.6;
+}
+
+.stage h3 {
+    position: relative;
+    font-size: 1.3rem;
+    margin-bottom: 0.75rem;
+}
+
+.stage p {
+    position: relative;
+    color: var(--muted);
+    margin-bottom: 1rem;
+}
+
+.stage ul {
+    position: relative;
+    list-style: none;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.stage li::before {
+    content: '•';
+    color: var(--accent);
+    margin-right: 0.5rem;
+}
+
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.team-card {
+    background: rgba(12, 14, 34, 0.55);
+    border-radius: var(--card-radius);
+    padding: 2rem;
+    border: 1px solid rgba(89, 193, 255, 0.12);
+    position: relative;
+    overflow: hidden;
+}
+
+.team-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(89, 193, 255, 0.25), transparent 60%);
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.team-card h3 {
+    font-size: 1.35rem;
+    margin-bottom: 0.75rem;
+}
+
+.team-card p {
+    color: var(--muted);
+    position: relative;
+}
+
+.tag {
+    display: inline-flex;
+    margin-top: 1.5rem;
+    padding: 0.35rem 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.prize-list {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    margin: 2rem 0;
+}
+
+.prize-list li {
+    display: flex;
+    justify-content: space-between;
+    background: rgba(12, 14, 34, 0.55);
+    padding: 1rem 1.5rem;
+    border-radius: 14px;
+    border: 1px solid rgba(89, 193, 255, 0.12);
+}
+
+.partner-list {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    margin: 1.5rem 0;
+}
+
+.steps {
+    margin-top: 2rem;
+    display: grid;
+    gap: 1rem;
+    counter-reset: step;
+}
+
+.steps li {
+    counter-increment: step;
+    background: rgba(12, 14, 34, 0.5);
+    padding: 1rem 1.5rem;
+    border-radius: 14px;
+    border: 1px solid rgba(89, 193, 255, 0.12);
+}
+
+.steps li::before {
+    content: counter(step);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    margin-right: 0.75rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+    color: #0b0b18;
+    font-weight: 700;
+}
+
+.form {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.form label {
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.95rem;
+}
+
+input,
+textarea,
+select {
+    font: inherit;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(230, 232, 242, 0.15);
+    background: rgba(6, 6, 19, 0.75);
+    color: var(--text);
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(89, 193, 255, 0.18);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.form-note {
+    color: var(--muted);
+    font-size: 0.8rem;
+}
+
+.footer {
+    border-top: 1px solid rgba(89, 193, 255, 0.1);
+    background: rgba(6, 6, 19, 0.95);
+    padding: 3rem 0;
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 2rem;
+    align-items: center;
+}
+
+.footer-links,
+.socials {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.socials a {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+@media (max-width: 720px) {
+    .navigation {
+        flex-direction: column;
+        gap: 1.5rem;
+        text-align: center;
+    }
+
+    .nav-links {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .hero {
+        min-height: auto;
+        padding-top: 2rem;
+        padding-bottom: 4rem;
+    }
+
+    .hero-content {
+        text-align: center;
+    }
+
+    .hero-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        align-items: center;
+    }
+
+    .hero-stats {
+        margin-top: 2rem;
+    }
+
+    .countdown-timer {
+        grid-template-columns: repeat(2, minmax(80px, 1fr));
+    }
+
+    .prize-list li {
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
## Summary
- create a single-page CS2 Aurora Clash tournament site with hero, schedule, teams, prizes, and registration sections
- implement countdown widget and CTA links for stream and registration
- add responsive neon-inspired styling for layout, cards, and forms

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cd0534abb48330aad32839d2d654fc